### PR TITLE
Add `list_members` command

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -76,7 +76,7 @@ Examples:
 * `delete member -i 2`
 
 
-### Listing all members of the team : `list members`
+### Listing all members of the team : `list_members`
 
 View all the members currently in the team, in the form of a list.
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -80,7 +80,7 @@ Examples:
 
 View all the members currently in the team, in the form of a list.
 
-Format: `list members`
+Format: `list_members`
 
 ### Add task to team : `add_task`
 

--- a/src/main/java/seedu/address/logic/commands/ListMembersCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListMembersCommand.java
@@ -1,0 +1,43 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import seedu.address.commons.core.Messages;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.person.TeamPredicate;
+import seedu.address.model.team.Team;
+
+
+/**
+ * Lists all members of the current team.
+ */
+public class ListMembersCommand extends Command {
+    public static final String COMMAND_WORD = "list_members";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+        + ": Lists all the members of the current team.\n"
+        + "Example: " + COMMAND_WORD;
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+
+        List<Team> teams = new ArrayList<>();
+        teams.add(model.getTeam());
+        TeamPredicate predicate = new TeamPredicate(teams);
+
+        model.updateFilteredPersonList(predicate);
+        return new CommandResult(
+            String.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW, model.getFilteredPersonList().size()));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+            || (other instanceof ListMembersCommand); // instanceof handles nulls
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -17,6 +17,7 @@ import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
+import seedu.address.logic.commands.ListMembersCommand;
 import seedu.address.logic.commands.ListTasksCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
@@ -79,6 +80,9 @@ public class AddressBookParser {
 
         case ListTasksCommand.COMMAND_WORD:
             return new ListTasksCommand();
+
+        case ListMembersCommand.COMMAND_WORD:
+            return new ListMembersCommand();
 
         default:
             throw new ParseException(MESSAGE_UNKNOWN_COMMAND);

--- a/src/main/java/seedu/address/model/person/TeamPredicate.java
+++ b/src/main/java/seedu/address/model/person/TeamPredicate.java
@@ -1,0 +1,31 @@
+package seedu.address.model.person;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+import seedu.address.model.team.Team;
+
+/**
+ * Tests that a {@code Person} belongs to any of the {@code Team} specified.
+ */
+public class TeamPredicate implements Predicate<Person> {
+    private final List<Team> teams;
+
+    public TeamPredicate(List<Team> teams) {
+        this.teams = teams;
+    }
+
+    @Override
+    public boolean test(Person person) {
+        return teams.stream()
+                .anyMatch(team -> team.hasMember(person));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof TeamPredicate // instanceof handles nulls
+                && teams.equals(((TeamPredicate) other).teams)); // state check
+    }
+
+}

--- a/src/test/java/seedu/address/logic/commands/ListMembersCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ListMembersCommandTest.java
@@ -1,0 +1,45 @@
+package seedu.address.logic.commands;
+
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import seedu.address.commons.core.Messages;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.person.TeamPredicate;
+import seedu.address.model.team.Team;
+
+/**
+ * Contains integration tests (interaction with the Model) and unit tests for ListMembersCommand.
+ */
+public class ListMembersCommandTest {
+
+    private Model model;
+    private Model expectedModel;
+
+    @BeforeEach
+    public void setUp() {
+        model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+        expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+    }
+
+    @Test
+    public void execute_listMembers_success() {
+        List<Team> teams = new ArrayList<>();
+        teams.add(expectedModel.getTeam());
+        expectedModel.updateFilteredPersonList(new TeamPredicate(teams));
+
+        String expectedMessage = String.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW,
+            model.getTeam().getTeamMembers().size());
+        CommandResult expectedCommandResult = new CommandResult(expectedMessage);
+
+        assertCommandSuccess(new ListMembersCommand(), model, expectedCommandResult, expectedModel);
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -14,6 +14,7 @@ import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.AddCommand;
+import seedu.address.logic.commands.AddMemberCommand;
 import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.commands.EditCommand;
@@ -22,6 +23,7 @@ import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
+import seedu.address.logic.commands.ListMembersCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
 import seedu.address.model.person.Person;
@@ -86,6 +88,19 @@ public class AddressBookParserTest {
     public void parseCommand_list() throws Exception {
         assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD) instanceof ListCommand);
         assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD + " 3") instanceof ListCommand);
+    }
+
+    @Test
+    public void parseCommand_addMember() throws Exception {
+        AddMemberCommand command = (AddMemberCommand) parser.parseCommand(
+            AddMemberCommand.COMMAND_WORD + " " + INDEX_FIRST_PERSON.getOneBased());
+        assertEquals(new AddMemberCommand(INDEX_FIRST_PERSON), command);
+    }
+
+    @Test
+    public void parseCommand_listMembers() throws Exception {
+        assertTrue(parser.parseCommand(ListMembersCommand.COMMAND_WORD) instanceof ListMembersCommand);
+        assertTrue(parser.parseCommand(ListMembersCommand.COMMAND_WORD + " 3") instanceof ListMembersCommand);
     }
 
     @Test


### PR DESCRIPTION
# Changes
1. Add `ListMembersCommand` which filters the address book for people in the current team
2. Add `TeamPredicate` which checks whether the person is in the list of teams specified
3. Add relevant test cases (and a missing one for `AddMemberCommand` inside `seedu/address/logic/parser/AddressBookParserTest.java`

Fixes #32 