### PR TITLE
Update error message for assign task command 

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AssignTaskCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AssignTaskCommand.java
@@ -17,9 +17,9 @@ public class AssignTaskCommand extends Command {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
         + ": Assigns a task to the specified member in the team.\n"
-        + "Parameters: name of task \n"
+        + "Parameters: index of task \n"
             + "Parameters: name of person \n"
-        + "Example: " + COMMAND_WORD + " Review PR" + " Bernice Yu";
+        + "Example: " + COMMAND_WORD + " 1" + " Bernice Yu";
 
     public static final String MESSAGE_ASSIGN_TASK_SUCCESS = "Assigned Task: %1$s assigned to %2$s";
     public static final String MESSAGE_DUPLICATE_ASSIGNMENT = "This task has already been assigned to %1$s";


### PR DESCRIPTION
- Changed "name of task" to "index of task" for a more accurate error message displayed to user