### PR TITLE
Add aliases to all commands

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -9,7 +9,7 @@ import seedu.address.model.Model;
 /**
  * Command that contains all subcommands starting with {@code add}.
  */
-@CommandLine.Command(name = "add", subcommands = {
+@CommandLine.Command(name = "add", aliases = {"a"}, subcommands = {
     AddPersonCommand.class,
     AddMemberCommand.class,
     AddTaskCommand.class,

--- a/src/main/java/seedu/address/logic/commands/AddLinkCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddLinkCommand.java
@@ -16,7 +16,7 @@ import seedu.address.model.team.Url;
 /**
  * Adds a new link to TruthTable.
  */
-@CommandLine.Command(name = "link")
+@CommandLine.Command(name = "link", aliases = {"l"})
 public class AddLinkCommand extends Command {
     public static final String COMMAND_WORD = "add link";
 

--- a/src/main/java/seedu/address/logic/commands/AddMemberCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddMemberCommand.java
@@ -15,7 +15,7 @@ import seedu.address.model.team.Team;
 /**
  * Adds the person with the specified name to the current team.
  */
-@CommandLine.Command(name = "member")
+@CommandLine.Command(name = "member", aliases = {"m"})
 public class AddMemberCommand extends Command {
 
     public static final String COMMAND_WORD = "add member";

--- a/src/main/java/seedu/address/logic/commands/AddPersonCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddPersonCommand.java
@@ -29,7 +29,7 @@ import seedu.address.model.tag.Tag;
 /**
  * Adds a person to the address book.
  */
-@CommandLine.Command(name = "person")
+@CommandLine.Command(name = "person", aliases = {"p"})
 public class AddPersonCommand extends Command {
     public static final String COMMAND_WORD = "add person";
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a person to the address book. "

--- a/src/main/java/seedu/address/logic/commands/AddTaskCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddTaskCommand.java
@@ -10,7 +10,7 @@ import seedu.address.model.team.Task;
 /**
  * Adds a task to the current team.
  */
-@CommandLine.Command(name = "task")
+@CommandLine.Command(name = "task", aliases = {"ta"})
 public class AddTaskCommand extends Command {
     public static final String COMMAND_WORD = "add task";
 

--- a/src/main/java/seedu/address/logic/commands/AddTeamCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddTeamCommand.java
@@ -16,7 +16,7 @@ import seedu.address.model.team.Team;
 /**
  * Adds a new team to the address book.
  */
-@CommandLine.Command(name = "team")
+@CommandLine.Command(name = "team", aliases = {"te"})
 public class AddTeamCommand extends Command {
     public static final String COMMAND_WORD = "add team";
 

--- a/src/main/java/seedu/address/logic/commands/AssignCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AssignCommand.java
@@ -9,7 +9,7 @@ import seedu.address.model.Model;
 /**
  * Command that contains all subcommands starting with {@code assign}.
  */
-@CommandLine.Command(name = "assign", subcommands = {
+@CommandLine.Command(name = "assign", aliases = {"as"}, subcommands = {
     AssignTaskCommand.class,
     AssignTaskRandomlyCommand.class,
 })

--- a/src/main/java/seedu/address/logic/commands/AssignTaskCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AssignTaskCommand.java
@@ -19,7 +19,7 @@ import seedu.address.model.team.Task;
 /**
  * Assigns a task to a specific member in the team.
  */
-@CommandLine.Command(name = "task")
+@CommandLine.Command(name = "task", aliases = {"t"})
 public class AssignTaskCommand extends Command {
     public static final String COMMAND_WORD = "assign task";
 

--- a/src/main/java/seedu/address/logic/commands/AssignTaskRandomlyCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AssignTaskRandomlyCommand.java
@@ -16,7 +16,7 @@ import seedu.address.model.team.Task;
 /**
  * Assigns a task to a random member in the team.
  */
-@CommandLine.Command(name = "random")
+@CommandLine.Command(name = "random", aliases = {"r"})
 public class AssignTaskRandomlyCommand extends Command {
     public static final String COMMAND_WORD = "assign random";
 

--- a/src/main/java/seedu/address/logic/commands/ClearCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ClearCommand.java
@@ -9,7 +9,7 @@ import seedu.address.model.Model;
 /**
  * Clears the address book.
  */
-@CommandLine.Command(name = "clear")
+@CommandLine.Command(name = "clear", aliases = {"c"})
 public class ClearCommand extends Command {
 
     public static final String COMMAND_WORD = "clear";

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -9,7 +9,7 @@ import seedu.address.model.Model;
 /**
  * Command that contains all subcommands starting with {@code delete}.
  */
-@CommandLine.Command(name = "delete", subcommands = {
+@CommandLine.Command(name = "delete", aliases = {"d"}, subcommands = {
     DeleteLinkCommand.class,
     DeleteMemberCommand.class,
     DeletePersonCommand.class,

--- a/src/main/java/seedu/address/logic/commands/DeleteLinkCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteLinkCommand.java
@@ -14,7 +14,7 @@ import seedu.address.model.team.Link;
 /**
  * Deletes an existing link from TruthTable.
  */
-@CommandLine.Command(name = "link")
+@CommandLine.Command(name = "link", aliases = {"l"})
 public class DeleteLinkCommand extends Command {
     public static final String COMMAND_WORD = "delete link";
 

--- a/src/main/java/seedu/address/logic/commands/DeleteMemberCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteMemberCommand.java
@@ -14,7 +14,7 @@ import seedu.address.model.person.Person;
 /**
  * Deletes a member identified using it's displayed index from the member list.
  */
-@CommandLine.Command(name = "member")
+@CommandLine.Command(name = "member", aliases = {"m"})
 public class DeleteMemberCommand extends Command {
 
     public static final String COMMAND_WORD = "delete member";

--- a/src/main/java/seedu/address/logic/commands/DeletePersonCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeletePersonCommand.java
@@ -14,7 +14,7 @@ import seedu.address.model.person.Person;
 /**
  * Deletes a person identified using its displayed index from the address book.
  */
-@CommandLine.Command(name = "person")
+@CommandLine.Command(name = "person", aliases = {"p"})
 public class DeletePersonCommand extends Command {
 
     public static final String COMMAND_WORD = "delete person";

--- a/src/main/java/seedu/address/logic/commands/DeleteTaskCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteTaskCommand.java
@@ -14,7 +14,7 @@ import seedu.address.model.team.Task;
 /**
  * Deletes a task identified using its displayed index from the task list.
  */
-@CommandLine.Command(name = "task")
+@CommandLine.Command(name = "task", aliases = {"ta"})
 public class DeleteTaskCommand extends Command {
 
     public static final String COMMAND_WORD = "delete task";

--- a/src/main/java/seedu/address/logic/commands/DeleteTeamCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteTeamCommand.java
@@ -12,7 +12,7 @@ import seedu.address.model.team.Team;
 /**
  * Deletes a team from the addressbook.
  */
-@CommandLine.Command(name = "team")
+@CommandLine.Command(name = "team", aliases = {"te"})
 public class DeleteTeamCommand extends Command {
     public static final String COMMAND_WORD = "delete team";
 

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -9,7 +9,7 @@ import seedu.address.model.Model;
 /**
  * Command that contains all subcommands starting with {@code edit}.
  */
-@CommandLine.Command(name = "edit", subcommands = {
+@CommandLine.Command(name = "edit", aliases = {"e"}, subcommands = {
     EditLinkCommand.class,
     EditPersonCommand.class,
 })

--- a/src/main/java/seedu/address/logic/commands/EditLinkCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditLinkCommand.java
@@ -23,7 +23,7 @@ import seedu.address.model.team.Url;
 /**
  * Edits the details of an existing link in TruthTable.
  */
-@CommandLine.Command(name = "link")
+@CommandLine.Command(name = "link", aliases = {"l"})
 public class EditLinkCommand extends Command {
     public static final String COMMAND_WORD = "edit link";
 

--- a/src/main/java/seedu/address/logic/commands/EditPersonCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditPersonCommand.java
@@ -36,7 +36,7 @@ import seedu.address.model.tag.Tag;
 /**
  * Edits the details of an existing person in the address book.
  */
-@CommandLine.Command(name = "person")
+@CommandLine.Command(name = "person", aliases = {"p"})
 public class EditPersonCommand extends Command {
 
     public static final String COMMAND_WORD = "edit person";

--- a/src/main/java/seedu/address/logic/commands/EditTeamCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditTeamCommand.java
@@ -19,7 +19,7 @@ import seedu.address.model.team.Team;
 /**
  * Edits the currently set team.
  */
-@CommandLine.Command(name = "team")
+@CommandLine.Command(name = "team", aliases = {"te"})
 public class EditTeamCommand extends Command {
     public static final String COMMAND_WORD = "edit team";
 

--- a/src/main/java/seedu/address/logic/commands/ExitCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ExitCommand.java
@@ -7,7 +7,7 @@ import seedu.address.ui.MainWindow;
 /**
  * Terminates the program.
  */
-@CommandLine.Command(name = "exit")
+@CommandLine.Command(name = "exit", aliases = {"ex", "bye", "quit"})
 public class ExitCommand extends Command {
 
     public static final String COMMAND_WORD = "exit";

--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -11,7 +11,7 @@ import seedu.address.model.person.NameContainsKeywordsPredicate;
  * Finds and lists all persons in address book whose name contains any of the argument keywords.
  * Keyword matching is case-insensitive.
  */
-@CommandLine.Command(name = "find")
+@CommandLine.Command(name = "find", aliases = {"f"})
 public class FindCommand extends Command {
 
     public static final String COMMAND_WORD = "find";

--- a/src/main/java/seedu/address/logic/commands/HelpCommand.java
+++ b/src/main/java/seedu/address/logic/commands/HelpCommand.java
@@ -6,7 +6,7 @@ import seedu.address.model.Model;
 /**
  * Format full help instructions for every command for display.
  */
-@CommandLine.Command(name = "help")
+@CommandLine.Command(name = "help", aliases = {"h"})
 public class HelpCommand extends Command {
 
     public static final String COMMAND_WORD = "help";

--- a/src/main/java/seedu/address/logic/commands/ListCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListCommand.java
@@ -9,7 +9,7 @@ import seedu.address.model.Model;
 /**
  * Command that contains all subcommands starting with {@code list}.
  */
-@CommandLine.Command(name = "list", subcommands = {
+@CommandLine.Command(name = "list", aliases = {"l"}, subcommands = {
     ListPersonsCommand.class,
     ListMembersCommand.class,
     ListTasksCommand.class

--- a/src/main/java/seedu/address/logic/commands/ListMembersCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListMembersCommand.java
@@ -12,7 +12,7 @@ import seedu.address.model.person.TeamPredicate;
 /**
  * Lists all members of the current team.
  */
-@CommandLine.Command(name = "members")
+@CommandLine.Command(name = "members", aliases = {"m"})
 public class ListMembersCommand extends Command {
     public static final String COMMAND_WORD = "list members";
 

--- a/src/main/java/seedu/address/logic/commands/ListPersonsCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListPersonsCommand.java
@@ -9,7 +9,7 @@ import seedu.address.model.Model;
 /**
  * Lists all persons in the address book to the user.
  */
-@CommandLine.Command(name = "persons")
+@CommandLine.Command(name = "persons", aliases = {"p"})
 public class ListPersonsCommand extends Command {
 
     public static final String COMMAND_WORD = "list persons";

--- a/src/main/java/seedu/address/logic/commands/ListTasksCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListTasksCommand.java
@@ -16,7 +16,7 @@ import seedu.address.model.Model;
 /**
  * Lists all tasks of the current team.
  */
-@CommandLine.Command(name = "tasks")
+@CommandLine.Command(name = "tasks", aliases = {"t"})
 public class ListTasksCommand extends Command {
     public static final String COMMAND_WORD = "list tasks";
 

--- a/src/main/java/seedu/address/logic/commands/MarkCommand.java
+++ b/src/main/java/seedu/address/logic/commands/MarkCommand.java
@@ -13,7 +13,7 @@ import seedu.address.model.team.Task;
 /**
  * Marks a specified task as complete.
  */
-@CommandLine.Command(name = "mark")
+@CommandLine.Command(name = "mark", aliases = {"m"})
 public class MarkCommand extends Command {
     public static final String COMMAND_WORD = "mark";
 

--- a/src/main/java/seedu/address/logic/commands/SetCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SetCommand.java
@@ -9,7 +9,7 @@ import seedu.address.model.Model;
 /**
  * Command that contains all subcommands starting with set.
  */
-@CommandLine.Command(name = "set", subcommands = {
+@CommandLine.Command(name = "set", aliases = {"s"}, subcommands = {
     SetDeadlineCommand.class,
     SetTeamCommand.class,
 })

--- a/src/main/java/seedu/address/logic/commands/SetDeadlineCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SetDeadlineCommand.java
@@ -15,7 +15,7 @@ import seedu.address.model.team.Task;
 /**
  * Sets a deadline for a specified task.
  */
-@CommandLine.Command(name = "deadline")
+@CommandLine.Command(name = "deadline", aliases = {"d"})
 public class SetDeadlineCommand extends Command {
     public static final String COMMAND_WORD = "set deadline";
 

--- a/src/main/java/seedu/address/logic/commands/SetTeamCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SetTeamCommand.java
@@ -12,7 +12,7 @@ import seedu.address.model.team.Team;
 /**
  * Sets the current team to an existing team.
  */
-@CommandLine.Command(name = "team")
+@CommandLine.Command(name = "team", aliases = {"t"})
 public class SetTeamCommand extends Command {
     public static final String COMMAND_WORD = "set team";
 

--- a/src/main/java/seedu/address/logic/commands/TasksSummaryCommand.java
+++ b/src/main/java/seedu/address/logic/commands/TasksSummaryCommand.java
@@ -14,7 +14,7 @@ import seedu.address.model.person.Person;
 /**
  * Displays a summary of how tasks have been assigned in the current team.
  */
-@CommandLine.Command(name = "summary")
+@CommandLine.Command(name = "summary", aliases = {"su", "sum"})
 public class TasksSummaryCommand extends Command {
     public static final String COMMAND_WORD = "summary";
 

--- a/src/main/java/seedu/address/logic/commands/UnmarkCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UnmarkCommand.java
@@ -13,7 +13,7 @@ import seedu.address.model.team.Task;
 /**
  * Marks a specified task as incomplete.
  */
-@CommandLine.Command(name = "unmark")
+@CommandLine.Command(name = "unmark", aliases = {"u"})
 public class UnmarkCommand extends Command {
     public static final String COMMAND_WORD = "unmark";
 


### PR DESCRIPTION
# Changes
- Add aliases for all commands 

# Note
Aliases naturally have to be unique, so for commands with both `team` and `task` subcommands, I made use of the first 2 characters instead (i.e. `te` and `ta`)

Fixes #98 