### PR TITLE
Edit Team Fix

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddTeamCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddTeamCommand.java
@@ -39,7 +39,7 @@ public class AddTeamCommand extends Command {
     @CommandLine.Option(names = {FLAG_NAME_STR, FLAG_NAME_STR_LONG}, required = true)
     private String teamName;
 
-    @CommandLine.Option(names = {FLAG_DESCRIPTION_STR, FLAG_DESCRIPTION_LONG}, defaultValue = "")
+    @CommandLine.Option(names = {FLAG_DESCRIPTION_STR, FLAG_DESCRIPTION_LONG}, defaultValue = Team.DEFAULT_DESCRIPTION)
     private String description;
 
     public AddTeamCommand() {

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -10,6 +10,7 @@ import seedu.address.model.Model;
  * Command that contains all subcommands starting with {@code edit}.
  */
 @CommandLine.Command(name = "edit", subcommands = {
+        EditTeamCommand.class,
     EditLinkCommand.class,
     EditPersonCommand.class,
 })

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -10,7 +10,7 @@ import seedu.address.model.Model;
  * Command that contains all subcommands starting with {@code edit}.
  */
 @CommandLine.Command(name = "edit", subcommands = {
-        EditTeamCommand.class,
+    EditTeamCommand.class,
     EditLinkCommand.class,
     EditPersonCommand.class,
 })

--- a/src/main/java/seedu/address/logic/commands/EditTeamCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditTeamCommand.java
@@ -42,7 +42,7 @@ public class EditTeamCommand extends Command {
 
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
 
-    public static final String MESSAGE_DUPLICATE_TEAM = "This team ame already exists in the address book.";
+    public static final String MESSAGE_DUPLICATE_TEAM = "This team name already exists in the address book.";
     @CommandLine.ArgGroup(exclusive = false, multiplicity = "1")
     private Arguments arguments;
 

--- a/src/main/java/seedu/address/logic/commands/EditTeamCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditTeamCommand.java
@@ -14,6 +14,9 @@ import picocli.CommandLine;
 import seedu.address.commons.util.CollectionUtil;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
+import seedu.address.model.person.Person;
+import seedu.address.model.team.Link;
+import seedu.address.model.team.Task;
 import seedu.address.model.team.Team;
 
 /**
@@ -66,8 +69,11 @@ public class EditTeamCommand extends Command {
 
         String updatedName = editTeamDescriptor.getName().orElse(teamToEdit.getTeamName());
         String updatedDescription = editTeamDescriptor.getDescription().orElse(teamToEdit.getDescription());
+        List<Person> members = teamToEdit.getTeamMembers();
+        List<Task> tasks = teamToEdit.getTaskList();
+        List<Link> links = teamToEdit.getLinkList();
 
-        return new Team(updatedName, updatedDescription);
+        return new Team(updatedName, updatedDescription, members, tasks, links);
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/EditTeamCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditTeamCommand.java
@@ -39,7 +39,7 @@ public class EditTeamCommand extends Command {
 
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
 
-    public static final String MESSAGE_DUPLICATE_TEAM = "This team name already exists in the address book.";
+    public static final String MESSAGE_DUPLICATE_TEAM = "This team ame already exists in the address book.";
     @CommandLine.ArgGroup(exclusive = false, multiplicity = "1")
     private Arguments arguments;
 


### PR DESCRIPTION
### Fixes
1. Fixed a bug where add team without a description will cause a bug
2. Fixed a bug where edit team will result in deletion of all members and tasks
3. Add edit team as a subcommand of edit command.