### PR TITLE
Fix ListTasksCommand `-i` and `-c` flags

### DIFF
--- a/src/main/java/seedu/address/logic/commands/ListTasksCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListTasksCommand.java
@@ -22,7 +22,7 @@ import seedu.address.model.team.Task;
 /**
  * Lists all tasks of the current team.
  */
-@CommandLine.Command(name = "tasks", aliases = { "t" }, mixinStandardHelpOptions = true)
+@CommandLine.Command(name = "tasks", aliases = {"t"}, mixinStandardHelpOptions = true)
 public class ListTasksCommand extends Command {
     public static final String COMMAND_WORD = "list tasks";
 
@@ -39,11 +39,11 @@ public class ListTasksCommand extends Command {
             + "Type `list tasks` to show all tasks again.";
 
 
-    @CommandLine.Option(names = { FLAG_COMPLETE_TASKS_STR, FLAG_COMPLETE_TASKS_STR_LONG },
+    @CommandLine.Option(names = {FLAG_COMPLETE_TASKS_STR, FLAG_COMPLETE_TASKS_STR_LONG},
             description = FLAG_COMPLETE_TASK_DESCRIPTION)
     private boolean hasCompleteFlag;
 
-    @CommandLine.Option(names = { FLAG_INCOMPLETE_TASKS_STR, FLAG_INCOMPLETE_TASKS_STR_LONG }, description =
+    @CommandLine.Option(names = {FLAG_INCOMPLETE_TASKS_STR, FLAG_INCOMPLETE_TASKS_STR_LONG}, description =
             FLAG_INCOMPLETE_TASK_DESCRIPTION)
     private boolean hasIncompleteFlag;
 

--- a/src/main/java/seedu/address/logic/commands/ListTasksCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListTasksCommand.java
@@ -4,6 +4,9 @@ import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.parser.CliSyntax.FLAG_COMPLETE_TASKS_STR;
 import static seedu.address.logic.parser.CliSyntax.FLAG_COMPLETE_TASKS_STR_LONG;
 import static seedu.address.logic.parser.CliSyntax.FLAG_COMPLETE_TASK_DESCRIPTION;
+import static seedu.address.logic.parser.CliSyntax.FLAG_HELP_DESCRIPTION;
+import static seedu.address.logic.parser.CliSyntax.FLAG_HELP_STR;
+import static seedu.address.logic.parser.CliSyntax.FLAG_HELP_STR_LONG;
 import static seedu.address.logic.parser.CliSyntax.FLAG_INCOMPLETE_TASKS_STR;
 import static seedu.address.logic.parser.CliSyntax.FLAG_INCOMPLETE_TASKS_STR_LONG;
 import static seedu.address.logic.parser.CliSyntax.FLAG_INCOMPLETE_TASK_DESCRIPTION;
@@ -44,11 +47,22 @@ public class ListTasksCommand extends Command {
             FLAG_INCOMPLETE_TASK_DESCRIPTION)
     private boolean hasIncompleteFlag;
 
+    @CommandLine.Option(names = {FLAG_HELP_STR, FLAG_HELP_STR_LONG}, usageHelp = true,
+            description = FLAG_HELP_DESCRIPTION)
+    private boolean help;
+
+    @CommandLine.Spec
+    private CommandLine.Model.CommandSpec commandSpec;
+
     public ListTasksCommand() {
     }
 
     @Override
     public CommandResult execute(Model model) throws CommandException {
+        if (commandSpec.commandLine().isUsageHelpRequested()) {
+            return new CommandResult(commandSpec.commandLine().getUsageMessage());
+        }
+
         requireNonNull(model);
 
         if ((hasCompleteFlag == hasIncompleteFlag)) {

--- a/src/main/java/seedu/address/logic/commands/ListTasksCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListTasksCommand.java
@@ -4,7 +4,6 @@ import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.parser.CliSyntax.FLAG_COMPLETE_TASKS_STR;
 import static seedu.address.logic.parser.CliSyntax.FLAG_COMPLETE_TASKS_STR_LONG;
 import static seedu.address.logic.parser.CliSyntax.FLAG_COMPLETE_TASK_DESCRIPTION;
-import static seedu.address.logic.parser.CliSyntax.FLAG_FILTER_STR;
 import static seedu.address.logic.parser.CliSyntax.FLAG_INCOMPLETE_TASKS_STR;
 import static seedu.address.logic.parser.CliSyntax.FLAG_INCOMPLETE_TASKS_STR_LONG;
 import static seedu.address.logic.parser.CliSyntax.FLAG_INCOMPLETE_TASK_DESCRIPTION;
@@ -26,18 +25,19 @@ public class ListTasksCommand extends Command {
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Lists all the tasks of the current team.\n"
             + "To view only incomplete or completed tasks, add "
-            + "-" + FLAG_FILTER_STR + " i (for incomplete tasks) or c (for completed tasks) \n"
+            + FLAG_INCOMPLETE_TASKS_STR + "(for incomplete tasks) or "
+            + FLAG_COMPLETE_TASKS_STR + " (for completed tasks) \n"
             + "Example: " + COMMAND_WORD;
 
     public static final String MESSAGE_LIST_TASK_SUCCESS = "Tasks: \n%1$s";
 
     @CommandLine.Option(names = {FLAG_COMPLETE_TASKS_STR, FLAG_COMPLETE_TASKS_STR_LONG},
             description = FLAG_COMPLETE_TASK_DESCRIPTION)
-    private Boolean isComplete;
+    private boolean hasCompleteFlag;
 
     @CommandLine.Option(names = {FLAG_INCOMPLETE_TASKS_STR, FLAG_INCOMPLETE_TASKS_STR_LONG}, description =
             FLAG_INCOMPLETE_TASK_DESCRIPTION)
-    private Boolean isIncomplete;
+    private boolean hasIncompleteFlag;
 
     public ListTasksCommand() {
     }
@@ -52,12 +52,12 @@ public class ListTasksCommand extends Command {
             return new CommandResult(NO_TASKS);
         }
 
-        if ((isComplete == isIncomplete)) {
+        if ((hasCompleteFlag == hasIncompleteFlag)) {
             model.updateFilteredTaskList(PREDICATE_SHOW_ALL_TASKS);
             return new CommandResult(String.format(MESSAGE_LIST_TASK_SUCCESS, tasks));
-        } else if (isComplete) {
+        } else if (hasCompleteFlag) {
             return new CommandResult(String.format(MESSAGE_LIST_TASK_SUCCESS, completedTasks));
-        } else if (isIncomplete) {
+        } else if (hasIncompleteFlag) {
             return new CommandResult(String.format(MESSAGE_LIST_TASK_SUCCESS, incompleteTasks));
         }
         return new CommandResult("Invalid command format!\n" + MESSAGE_USAGE);
@@ -67,7 +67,7 @@ public class ListTasksCommand extends Command {
     public boolean equals(Object other) {
         return other == this // short circuit if same object
                 || (other instanceof ListTasksCommand
-                && isComplete == ((ListTasksCommand) other).isComplete
-                && isIncomplete == ((ListTasksCommand) other).isIncomplete); // instanceof handles nulls
+                && hasCompleteFlag == ((ListTasksCommand) other).hasCompleteFlag
+                && hasIncompleteFlag == ((ListTasksCommand) other).hasIncompleteFlag); // instanceof handles nulls
     }
 }

--- a/src/main/java/seedu/address/logic/commands/ListTasksCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListTasksCommand.java
@@ -8,17 +8,18 @@ import static seedu.address.logic.parser.CliSyntax.FLAG_INCOMPLETE_TASKS_STR;
 import static seedu.address.logic.parser.CliSyntax.FLAG_INCOMPLETE_TASKS_STR_LONG;
 import static seedu.address.logic.parser.CliSyntax.FLAG_INCOMPLETE_TASK_DESCRIPTION;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_TASKS;
-import static seedu.address.model.team.TaskList.NO_TASKS;
 
 import picocli.CommandLine;
+import seedu.address.commons.core.Messages;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
+import seedu.address.model.team.Task;
 
 
 /**
  * Lists all tasks of the current team.
  */
-@CommandLine.Command(name = "tasks", aliases = {"t"}, mixinStandardHelpOptions = true)
+@CommandLine.Command(name = "tasks", aliases = { "t" }, mixinStandardHelpOptions = true)
 public class ListTasksCommand extends Command {
     public static final String COMMAND_WORD = "list tasks";
 
@@ -29,13 +30,17 @@ public class ListTasksCommand extends Command {
             + FLAG_COMPLETE_TASKS_STR + " (for completed tasks) \n"
             + "Example: " + COMMAND_WORD;
 
-    public static final String MESSAGE_LIST_TASK_SUCCESS = "Tasks: \n%1$s";
+    public static final String MESSAGE_LIST_COMPLETE_TASKS_SUCCESS = "Showing all %1$d completed task(s).\n"
+            + "Type `list tasks` to show all tasks again.";
+    public static final String MESSAGE_LIST_INCOMPLETE_TASKS_SUCCESS = "Showing all %1$d incomplete task(s).\n"
+            + "Type `list tasks` to show all tasks again.";
 
-    @CommandLine.Option(names = {FLAG_COMPLETE_TASKS_STR, FLAG_COMPLETE_TASKS_STR_LONG},
+
+    @CommandLine.Option(names = { FLAG_COMPLETE_TASKS_STR, FLAG_COMPLETE_TASKS_STR_LONG },
             description = FLAG_COMPLETE_TASK_DESCRIPTION)
     private boolean hasCompleteFlag;
 
-    @CommandLine.Option(names = {FLAG_INCOMPLETE_TASKS_STR, FLAG_INCOMPLETE_TASKS_STR_LONG}, description =
+    @CommandLine.Option(names = { FLAG_INCOMPLETE_TASKS_STR, FLAG_INCOMPLETE_TASKS_STR_LONG }, description =
             FLAG_INCOMPLETE_TASK_DESCRIPTION)
     private boolean hasIncompleteFlag;
 
@@ -45,20 +50,19 @@ public class ListTasksCommand extends Command {
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
-        String tasks = model.getTeam().getTasksAsString();
-        String completedTasks = model.getTeam().getCompletedTasksAsString();
-        String incompleteTasks = model.getTeam().getIncompleteTasksAsString();
-        if (tasks.equals(NO_TASKS)) {
-            return new CommandResult(NO_TASKS);
-        }
 
         if ((hasCompleteFlag == hasIncompleteFlag)) {
             model.updateFilteredTaskList(PREDICATE_SHOW_ALL_TASKS);
-            return new CommandResult(String.format(MESSAGE_LIST_TASK_SUCCESS, tasks));
+            return new CommandResult(String.format(Messages.MESSAGE_TASKS_LISTED_OVERVIEW,
+                    model.getFilteredTaskList().size()));
         } else if (hasCompleteFlag) {
-            return new CommandResult(String.format(MESSAGE_LIST_TASK_SUCCESS, completedTasks));
+            model.updateFilteredTaskList(Task::isComplete);
+            return new CommandResult(String.format(MESSAGE_LIST_COMPLETE_TASKS_SUCCESS,
+                    model.getFilteredTaskList().size()));
         } else if (hasIncompleteFlag) {
-            return new CommandResult(String.format(MESSAGE_LIST_TASK_SUCCESS, incompleteTasks));
+            model.updateFilteredTaskList((task) -> !task.isComplete());
+            return new CommandResult(String.format(MESSAGE_LIST_INCOMPLETE_TASKS_SUCCESS,
+                    model.getFilteredTaskList().size()));
         }
         return new CommandResult("Invalid command format!\n" + MESSAGE_USAGE);
     }

--- a/src/main/java/seedu/address/logic/commands/MarkCommand.java
+++ b/src/main/java/seedu/address/logic/commands/MarkCommand.java
@@ -64,7 +64,7 @@ public class MarkCommand extends Command {
         model.getTeam().setTask(originalTask, markedTask);
 
         return new CommandResult(String.format(MESSAGE_MARK_SUCCESS,
-                taskList.get(taskIndex.getZeroBased()).getName()));
+                markedTask.getName()));
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/UnmarkCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UnmarkCommand.java
@@ -60,7 +60,7 @@ public class UnmarkCommand extends Command {
         model.getTeam().setTask(originalTask, unmarkedTask);
 
         return new CommandResult(String.format(MESSAGE_MARK_SUCCESS,
-                taskList.get(taskIndex.getZeroBased()).getName()));
+                unmarkedTask.getName()));
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -18,12 +18,8 @@ public class CliSyntax {
     public static final String FLAG_DEADLINE_STR_LONG = "--deadline";
     public static final String FLAG_EMAIL_STR = "-e";
     public static final String FLAG_EMAIL_STR_LONG = "--email";
-    public static final String FLAG_FILTER_STR = "-f";
-    public static final String FLAG_FILTER_STR_LONG = "--filter";
     public static final String FLAG_HELP_STR = "-h";
     public static final String FLAG_HELP_STR_LONG = "--help";
-    public static final String FLAG_INDEX_STR = "-i";
-    public static final String FLAG_INDEX_STR_LONG = "--index";
     public static final String FLAG_INCOMPLETE_TASKS_STR = "-i";
     public static final String FLAG_INCOMPLETE_TASKS_STR_LONG = "--incomplete";
     public static final String FLAG_URL_STR = "-l";

--- a/src/main/java/seedu/address/model/team/TaskList.java
+++ b/src/main/java/seedu/address/model/team/TaskList.java
@@ -20,8 +20,6 @@ import seedu.address.model.person.exceptions.TaskNotFoundException;
  * Supports a minimal set of list operations.
  */
 public class TaskList implements Iterable<Task> {
-    public static final String NO_TASKS = "No Tasks Available";
-
     private final ObservableList<Task> internalList = FXCollections.observableArrayList();
     private final ObservableList<Task> internalUnmodifiableList =
             FXCollections.unmodifiableObservableList(internalList);

--- a/src/main/java/seedu/address/ui/TaskListPanel.java
+++ b/src/main/java/seedu/address/ui/TaskListPanel.java
@@ -48,7 +48,7 @@ public class TaskListPanel extends UiPart<Region> {
             taskCompletion.setText(
                     String.format("%d of %d (%,.1f%%) completed", numCompletedTasks, numTasks, completionPercentage));
         } else {
-            taskCompletion.setText("No tasks added yet!");
+            taskCompletion.setText("No tasks found");
         }
     }
 


### PR DESCRIPTION
Updated implementation to now update filtered list (i.e. list should change when you type `list tasks -i` or `-c`)

Bugfix: Previously it caused a Null Pointer Error due to use of boxed `Boolean` which could be `null` rather than simply `false`


Fixes #167 
Fixes #150 
Fixes #127 