### PR TITLE
Standardise DateTime formatters to use strict resolver styles

### DIFF
--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -5,6 +5,7 @@ import static java.util.Objects.requireNonNull;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
+import java.time.format.ResolverStyle;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
@@ -171,9 +172,15 @@ public class ParserUtil {
      */
     public static LocalDateTime parseLocalDateTime(String datetime) throws ParseException {
         try {
-            DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm");
+            DateTimeFormatter formatter = DateTimeFormatter
+                    .ofPattern("uuuu-MM-dd HH:mm")
+                    .withResolverStyle(ResolverStyle.STRICT);
             return LocalDateTime.parse(datetime, formatter);
         } catch (DateTimeParseException | NumberFormatException e) {
+            String[] message = e.getMessage().split(": ", 2);
+            if (message.length == 2) {
+                throw new ParseException(MESSAGE_INVALID_DATETIME + "\n" + message[1]);
+            }
             throw new ParseException(MESSAGE_INVALID_DATETIME);
         }
     }

--- a/src/main/java/seedu/address/model/team/Task.java
+++ b/src/main/java/seedu/address/model/team/Task.java
@@ -120,7 +120,7 @@ public class Task {
         if (deadline == null) {
             return "";
         } else {
-            return deadline.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm"));
+            return deadline.format(DateTimeFormatter.ofPattern("uuuu-MM-dd HH:mm"));
         }
     }
 

--- a/src/main/java/seedu/address/storage/JsonAdaptedTask.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedTask.java
@@ -2,6 +2,7 @@ package seedu.address.storage;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.time.format.ResolverStyle;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -21,7 +22,7 @@ class JsonAdaptedTask {
 
     private final String taskName;
     private final List<JsonAdaptedPerson> assignees = new ArrayList<>();
-    private String isComplete;
+    private final String isComplete;
     private final String deadline;
 
     /**
@@ -68,13 +69,12 @@ class JsonAdaptedTask {
         TaskName newTaskName = new TaskName(taskName);
         LocalDateTime deadline = null;
         if (!this.deadline.equals("")) {
-            DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm");
+            DateTimeFormatter formatter = DateTimeFormatter
+                    .ofPattern("uuuu-MM-dd HH:mm")
+                    .withResolverStyle(ResolverStyle.STRICT);
             deadline = LocalDateTime.parse(this.deadline, formatter);
         }
-        boolean isComplete = false;
-        if (this.isComplete.equals("true")) {
-            isComplete = true;
-        }
+        boolean isComplete = this.isComplete.equals("true");
         return new Task(newTaskName, assigneeList, isComplete, deadline);
     }
 


### PR DESCRIPTION
# Changes
- Add `ResolverStyle.STRICT` as referenced in the issue
- Update the error message to be more informative by including the message from `DateTimeException`

Fixes #184 