### PR TITLE
Update Names to allow all chars besides quotes

### DIFF
--- a/src/main/java/seedu/address/model/person/Name.java
+++ b/src/main/java/seedu/address/model/person/Name.java
@@ -10,13 +10,13 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
 public class Name {
 
     public static final String MESSAGE_CONSTRAINTS =
-            "Names should only contain alphanumeric characters and spaces, and it should not be blank";
+            "Person names cannot contain either single (') or double quotes (\"), and should not be blank";
 
     /*
      * The first character of the address must not be a whitespace,
      * otherwise " " (a blank string) becomes a valid input.
      */
-    public static final String VALIDATION_REGEX = "[\\p{Alnum}][\\p{Alnum} ]*";
+    public static final String VALIDATION_REGEX = "^[^'\\s\"][^'\"]+$";
 
     public final String fullName;
 

--- a/src/main/java/seedu/address/model/person/Name.java
+++ b/src/main/java/seedu/address/model/person/Name.java
@@ -10,7 +10,7 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
 public class Name {
 
     public static final String MESSAGE_CONSTRAINTS =
-            "Person names cannot contain either single (') or double quotes (\"), and should not be blank";
+            "Person names should not be blank and cannot contain quotation marks (' and \")";
 
     /*
      * The first character of the address must not be a whitespace,

--- a/src/main/java/seedu/address/model/team/Description.java
+++ b/src/main/java/seedu/address/model/team/Description.java
@@ -10,9 +10,9 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
 public class Description {
 
     public static final String MESSAGE_CONSTRAINTS =
-            "Team description should only contain alphanumeric characters and spaces, and it should not be blank";
+            "Team descriptions cannot contain either single (') or double quotes (\"), and should not be blank";
 
-    public static final String VALIDATION_REGEX = "[\\p{Alnum}][\\p{Alnum} ]*";
+    public static final String VALIDATION_REGEX = "^[^'\\s\"][^'\"]+$";
     public static final String NO_DESCRIPTION_STRING = "No description added";
     public static final Description NO_DESCRIPTION = new Description(NO_DESCRIPTION_STRING);
     public static final Description DEFAULT_DESCRIPTION = new Description("A default team created just for you");

--- a/src/main/java/seedu/address/model/team/Description.java
+++ b/src/main/java/seedu/address/model/team/Description.java
@@ -10,7 +10,7 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
 public class Description {
 
     public static final String MESSAGE_CONSTRAINTS =
-            "Team descriptions should not be blank and cannot contain quotation marks (' or \")";
+            "Team descriptions should not be blank and cannot contain quotation marks (' and \")";
 
     public static final String VALIDATION_REGEX = "^[^'\\s\"][^'\"]+$";
     public static final String NO_DESCRIPTION_STRING = "No description added";

--- a/src/main/java/seedu/address/model/team/Description.java
+++ b/src/main/java/seedu/address/model/team/Description.java
@@ -10,7 +10,7 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
 public class Description {
 
     public static final String MESSAGE_CONSTRAINTS =
-            "Team descriptions cannot contain either single (') or double quotes (\"), and should not be blank";
+            "Team descriptions should not be blank and cannot contain quotation marks (' or \")";
 
     public static final String VALIDATION_REGEX = "^[^'\\s\"][^'\"]+$";
     public static final String NO_DESCRIPTION_STRING = "No description added";

--- a/src/main/java/seedu/address/model/team/LinkName.java
+++ b/src/main/java/seedu/address/model/team/LinkName.java
@@ -9,13 +9,13 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
  */
 public class LinkName {
     public static final String MESSAGE_CONSTRAINTS =
-            "Link names should only contain alphanumeric characters and spaces, and it should not be blank";
+            "Link names cannot contain either single (') or double quotes (\"), and should not be blank";
 
     /*
      * The first character of the address must not be a whitespace,
      * otherwise " " (a blank string) becomes a valid input.
      */
-    public static final String VALIDATION_REGEX = "[\\p{Alnum}][\\p{Alnum} ]*";
+    public static final String VALIDATION_REGEX = "^[^'\\s\"][^'\"]+$";
 
     public final String linkName;
 

--- a/src/main/java/seedu/address/model/team/LinkName.java
+++ b/src/main/java/seedu/address/model/team/LinkName.java
@@ -9,7 +9,7 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
  */
 public class LinkName {
     public static final String MESSAGE_CONSTRAINTS =
-            "Link names cannot contain single (') or double quotes (\"), and should not be blank";
+            "Link names should not be blank and cannot contain quotation marks (' and \")";
 
     /*
      * The first character of the address must not be a whitespace,

--- a/src/main/java/seedu/address/model/team/LinkName.java
+++ b/src/main/java/seedu/address/model/team/LinkName.java
@@ -9,7 +9,7 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
  */
 public class LinkName {
     public static final String MESSAGE_CONSTRAINTS =
-            "Link names cannot contain either single (') or double quotes (\"), and should not be blank";
+            "Link names cannot contain single (') or double quotes (\"), and should not be blank";
 
     /*
      * The first character of the address must not be a whitespace,

--- a/src/main/java/seedu/address/model/team/TeamName.java
+++ b/src/main/java/seedu/address/model/team/TeamName.java
@@ -10,10 +10,9 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
 public class TeamName {
 
     public static final String MESSAGE_CONSTRAINTS =
-            "Team description should only contain alphanumeric characters, cannot contain spaces "
-                    + "and it should not be blank";
+            "Team names cannot contain either single (') or double quotes (\"), and should not be blank";
 
-    public static final String VALIDATION_REGEX = "\\p{Alnum}+";
+    public static final String VALIDATION_REGEX = "^[^'\\s\"][^'\"]+$";
 
     public static final TeamName DEFAULT_NAME = new TeamName("default");
 

--- a/src/main/java/seedu/address/model/team/TeamName.java
+++ b/src/main/java/seedu/address/model/team/TeamName.java
@@ -10,7 +10,7 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
 public class TeamName {
 
     public static final String MESSAGE_CONSTRAINTS =
-            "Team names cannot contain either single (') or double quotes (\"), and should not be blank";
+            "Team names should not be blank and cannot contain quotation marks (' and \")";
 
     public static final String VALIDATION_REGEX = "^[^'\\s\"][^'\"]+$";
 

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -20,7 +20,7 @@ import seedu.address.model.person.Phone;
 import seedu.address.model.tag.Tag;
 
 public class ParserUtilTest {
-    private static final String INVALID_NAME = "R@chel";
+    private static final String INVALID_NAME = "R'chel";
     private static final String INVALID_PHONE = "+651234";
     private static final String INVALID_ADDRESS = " ";
     private static final String INVALID_EMAIL = "example.com";

--- a/src/test/java/seedu/address/model/person/NameTest.java
+++ b/src/test/java/seedu/address/model/person/NameTest.java
@@ -27,8 +27,8 @@ public class NameTest {
         // invalid name
         assertFalse(Name.isValidName("")); // empty string
         assertFalse(Name.isValidName(" ")); // spaces only
-        assertFalse(Name.isValidName("^")); // only non-alphanumeric characters
-        assertFalse(Name.isValidName("peter*")); // contains non-alphanumeric characters
+        assertFalse(Name.isValidName("Marcus 'the legend' Pang")); // contains single quotes
+        assertFalse(Name.isValidName("Devansh \"the god\" Shah")); // contains double quotes
 
         // valid name
         assertTrue(Name.isValidName("peter jack")); // alphabets only
@@ -36,5 +36,7 @@ public class NameTest {
         assertTrue(Name.isValidName("peter the 2nd")); // alphanumeric characters
         assertTrue(Name.isValidName("Capital Tan")); // with capital letters
         assertTrue(Name.isValidName("David Roger Jackson Ray Jr 2nd")); // long names
+        assertTrue(Name.isValidName("Chang Jing !@#$%^&*() Yan")); // contains non-quote characters
+        assertTrue(Name.isValidName("Chang Jing `coder` Yan")); // contains backtick (not a quote)
     }
 }

--- a/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
@@ -17,7 +17,7 @@ import seedu.address.model.person.Name;
 import seedu.address.model.person.Phone;
 
 public class JsonAdaptedPersonTest {
-    private static final String INVALID_NAME = "R@chel";
+    private static final String INVALID_NAME = "R'chel";
     private static final String INVALID_PHONE = "+651234";
     private static final String INVALID_ADDRESS = " ";
     private static final String INVALID_EMAIL = "example.com";


### PR DESCRIPTION
Note: new tests should be updated to reflect this change

Closes #118 

**Manual test cases for reviewer:**
`add person -n "John S/O Doe" -p 98765432 -e johnd@example.com` should **work**
`add person -n "John'Doe" -p 98765432 -e johnd@example.com` should **not work**

`add link -n "Google (Bing but worse)" -l https://google.com` should **work**
`add link -n "Google 'kadabing' bong" -l https://google.com` should **not work**
`add link -n " " -l https://google.com` should **not work**