### PR TITLE
Fix add team, add task and edit team commands

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddTaskCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddTaskCommand.java
@@ -82,17 +82,12 @@ public class AddTaskCommand extends Command {
 
         Team team = model.getTeam();
         Task task = new Task(taskName, List.of(), false, deadline);
-        if (team.hasTask(task)) {
-            throw new CommandException(MESSAGE_DUPLICATE_TASK);
-        }
-
         List<Person> memberList = team.getTeamMembers();
         for (Index index : assignees) {
             if (index.getZeroBased() >= memberList.size()) {
                 throw new CommandException(MESSAGE_MEMBER_INDEX_OUT_OF_BOUNDS);
             }
         }
-
         // convert list of assignee index to list of persons
         List<Person> assigneePersonsList = assignees.stream()
                 .map(index -> memberList.get(index.getZeroBased()))
@@ -100,6 +95,10 @@ public class AddTaskCommand extends Command {
 
         for (Person assignee : assigneePersonsList) {
             task.addAssignee(assignee);
+        }
+
+        if (team.hasTask(task)) {
+            throw new CommandException(MESSAGE_DUPLICATE_TASK);
         }
         team.addTask(task);
 

--- a/src/main/java/seedu/address/logic/commands/AddTeamCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddTeamCommand.java
@@ -12,6 +12,7 @@ import static seedu.address.logic.parser.CliSyntax.LABEL_TEAM_DESCRIPTION;
 import static seedu.address.logic.parser.CliSyntax.LABEL_TEAM_NAME;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 import picocli.CommandLine;
 import seedu.address.logic.commands.exceptions.CommandException;
@@ -60,14 +61,17 @@ public class AddTeamCommand extends Command {
             return new CommandResult(HELP_MESSAGE + commandSpec.commandLine().getUsageMessage());
         }
         requireNonNull(model);
-        Team team = new Team(teamName, description);
+        Team targetTeam = new Team(teamName, description);
         List<Team> teamList = model.getTeamList();
-        if (teamList.contains(team)) {
+        List<Team> filteredListWithTargetTeam = teamList.stream()
+                .filter(targetTeam::isSameTeam).collect(Collectors.toList());
+
+        if (filteredListWithTargetTeam.size() == 1) {
             throw new CommandException(MESSAGE_TEAM_EXISTS);
         }
 
-        model.addTeam(team);
-        return new CommandResult(String.format(MESSAGE_ADD_TEAM_SUCCESS, team));
+        model.addTeam(targetTeam);
+        return new CommandResult(String.format(MESSAGE_ADD_TEAM_SUCCESS, targetTeam));
     }
 
 }

--- a/src/main/java/seedu/address/logic/commands/EditTeamCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditTeamCommand.java
@@ -16,6 +16,7 @@ import static seedu.address.logic.parser.CliSyntax.LABEL_TEAM_NAME;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import picocli.CommandLine;
 import seedu.address.commons.util.CollectionUtil;
@@ -94,7 +95,10 @@ public class EditTeamCommand extends Command {
         List<Team> teamList = model.getTeamList();
         List<Team> teamListCopy = new ArrayList<>(teamList);
 
-        if ((!editedTeam.isSameTeam(currentTeam)) && (teamListCopy.contains(editedTeam))) {
+        List<Team> filteredListWithTargetTeam = teamList.stream()
+                .filter(editedTeam::isSameTeam).collect(Collectors.toList());
+
+        if ((!editedTeam.isSameTeam(currentTeam)) && (filteredListWithTargetTeam.size() == 1)) {
             throw new CommandException(MESSAGE_DUPLICATE_TEAM);
         }
 

--- a/src/main/java/seedu/address/logic/commands/EditTeamCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditTeamCommand.java
@@ -98,7 +98,7 @@ public class EditTeamCommand extends Command {
         List<Team> filteredListWithTargetTeam = teamList.stream()
                 .filter(editedTeam::isSameTeam).collect(Collectors.toList());
 
-        if ((!editedTeam.isSameTeam(currentTeam)) && (filteredListWithTargetTeam.size() == 1)) {
+        if ((!editedTeam.isSameTeam(currentTeam)) && (filteredListWithTargetTeam.size() != 0)) {
             throw new CommandException(MESSAGE_DUPLICATE_TEAM);
         }
 


### PR DESCRIPTION
### Changes
1. Fixed a bug where `add team default` will not show an error message
2. Fixed a bug where adding the exact same task details will not show an error message
3. Fixed a bug where editing team to an existing team name will not show an error message

Fixes #209